### PR TITLE
Fixed wrong spawn point name on Hereford

### DIFF
--- a/site/js/r6-maps.map-data.js
+++ b/site/js/r6-maps.map-data.js
@@ -1064,7 +1064,7 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
         spawnPoints: [
           { letter: spawnTerms.a, top: 322, left: -789, description: herefordTerms.spawnTrainingCourse },
           { letter: spawnTerms.b, top: 236, left: 703, description: herefordTerms.spawnBarrak },
-          { letter: spawnTerms.c, top: -630, left: 27, description: herefordTerms.spawnTrainingCourse }
+          { letter: spawnTerms.c, top: -630, left: 27, description: herefordTerms.spawnShootingRange }
         ],
         roomLabels: [
           { floor: 0, top: 199, left: -100, description: herefordTerms.armory },


### PR DESCRIPTION
Spawn Point C is named "Training course" (the same as point A), this is a typo, since C is Shooting Range