### PR TITLE
Adding missing room labels for various maps

### DIFF
--- a/dev/js/langs/r6-maps.lang-terms.de.js
+++ b/dev/js/langs/r6-maps.lang-terms.de.js
@@ -86,6 +86,7 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
         bartlett: 'Bartlett U.',
         chalet: 'Chalet',
         club: 'Clubhaus',
+        coastline: 'Küste',
         consulate: 'Konsulat',
         hereford: 'Hereford-Basis',
         house: 'Haus',
@@ -161,6 +162,7 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           courtyard: 'Hof',
           centralHallway: 'Mittel-<br/>gang',
           diningRoom: 'Esszimmer',
+          eastBalcony: 'Ostbalkon<br/>( nicht gezeigt )',
           eastCorridor: 'Ost-<br/>korridor',
           eastStairs: 'Ost-<br/>treppe',
           festival: 'Fest',
@@ -186,6 +188,7 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           trophyRoom: 'Trophäen-<br/>raum',
           upperLibrary: 'Obere<br/>Bibliothek',
           vistaHallway: 'Offener<br/>Gang',
+          westBalcony: 'Westbalkon<br/>( nicht gezeigt )',
           westCorridor: 'West-<br/>korridor'
         },
         border: {
@@ -425,6 +428,8 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           schoolAlley: 'Schul-Gasse',
           footballPitch: 'Fußballfeld',
           market: 'Markt',
+          marketAlley: 'Markt-<br/>Gasse',
+          schoolRooftops: 'Schul-<br/>Dächer',
           street: 'Straße',
           rooftops: 'Dächer',
           courtyard: 'Hof',
@@ -434,10 +439,9 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: 'Ausbildungsparcours',
-          spawnBarrak: 'Parkplatz',
+          spawnParking: 'Parkplatz',
           spawnShootingRange: 'SchieBplatz',
           armory: 'Waffenlager',
-          alleyStairs: 'Seitentreppen-<br/>gasse',
           lockers: 'Spinde',
           corridor: 'Korridor',
           mainStairs: 'Haupt-<br/>treppe',
@@ -476,7 +480,8 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: 'Seitentreppen-<br/>gasse',
           sideStairs: 'Seiten-<br/>treppen',
           garageTop: 'Garagendach',
-          rooftop: 'Dach'
+          rooftop: 'Dach',
+          parkingEntrance: 'Parkplatz-einfahrt'
         },
         house: {
           spawnConstructionSite: 'Baustelle',
@@ -554,6 +559,7 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: 'Cocktail-<br/>Lounge-<br/>Eingang',
           westMainStreet: 'Westliche Hauptstraße',
           mainStreet: 'Hauptstraße',
+          eastMainStreet: 'Östliche Hauptstraße',
           bakeryParking: 'Bäckerei-<br/>Parkplatz',
           bakeryRoof: 'Bäckereidach',
           cafeRoofTop: 'Café-Dach',
@@ -617,7 +623,8 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: 'Kontrollzentrum-<br/>Dach',
           dockStairs: 'Dock-Treppe',
           parking: 'Parkplatz',
-          boatCrane: 'Bootskran'
+          boatCrane: 'Bootskran',
+          mapArchives: 'Karten-<br/>archiv'
         },
         oregon: {
           spawnJunkyard: 'Schrottplatz',
@@ -672,7 +679,8 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: 'Versammlungs-<br/>hallen-Eingang',
           garageRoof: 'Garagendach',
           dormsRoof: 'Schlafsaaldach',
-          meetingHallRoof: 'Versammlungs-<br/>hallendach'
+          meetingHallRoof: 'Versammlungs-<br/>hallendach',
+          supplyCloset: 'Vorrats-<br/>raum'
         },
         plane: {
           spawnOfficialEntrance: 'Haupteingang',
@@ -713,7 +721,8 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           caterer: 'Caterer',
           serverRoomA: 'Server-Raum A',
           serverRoomB: 'Server-Raum B',
-          technicalSeating: 'Technikersitz'
+          technicalSeating: 'Technikersitz',
+          ladderRoom: 'Leiter-<br/>raum'
         },
         skyscraper: {
           helipad: 'Helipad',
@@ -813,7 +822,11 @@ var R6MapsLangTermsGerman = (function(R6MapsLangTerms, undefined) {
           eastGlacier: 'Östliches Gletscher',
           frozenRiver: 'Gefrorener Fluss',
           zodiac: 'Schlauchboot',
-          westHullBreach: 'Westliches Leck'
+          westHullBreach: 'Westliches Leck',
+          kingOfTheWorld: 'König der<br/>Weit',
+          roof: 'Dach',
+          anchorName: 'Anker',
+          aklarkSubEntrance: 'Aklark<br/>U-Boot-Eingang'
         }
         //  ß  ä  Ä  é  ö  Ö  ü  Ü
       }

--- a/dev/js/langs/r6-maps.lang-terms.fr.js
+++ b/dev/js/langs/r6-maps.lang-terms.fr.js
@@ -90,6 +90,7 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
         border: 'Frontière',
         chalet: 'Chalet',
         club: 'Club House',
+        coastline: 'Littoral',
         consulate: 'Consulat',
         favela: 'Favelas',
         hereford: 'Hereford',
@@ -166,6 +167,7 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           courtyard: 'Cour',
           centralHallway: 'Couloir<br/>central',
           diningRoom: 'Salle à manger',
+          eastBalcony: 'Balcon est<br/>( pas montré )',
           eastCorridor: 'Couloir<br/>est',
           eastStairs: 'Escalier<br/>est',
           festival: 'Festival',
@@ -191,6 +193,7 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           trophyRoom: 'Salle des<br/>trophées',
           upperLibrary: 'Bibliothèque<br/>niv. supérieur',
           vistaHallway: 'Couloir<br/>dégagé',
+          westBalcony: 'Balcon ouest<br/>( pas montré )',
           westCorridor: 'Couloir<br/>ouest'
         },
         border: {
@@ -320,13 +323,14 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           schoolAlley: 'Allé de l\'école',
           footballPitch: 'Terrain de foot',
           market: 'Marché',
+          marketAlley: 'Allée du<br/>marché',
+          schoolRooftops: 'Toits de<br/>l\'école',
           street: 'Rue',
           rooftops: 'Toits',
           courtyard: 'Cour',
           accessAlley: 'Voie d\'accès',
           shop: 'Magasin<br/>( pas montré )',
           marketRooftops: 'Toits du marché'
-          //Allée du marché TO DO
         },
         kanal: {
           spawnFloatingDock: 'Quai flottant',
@@ -383,7 +387,8 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: 'Toit<br/>du centre<br/>de contrôle',
           dockStairs: 'Escalier du quai',
           parking: 'Parking',
-          boatCrane: 'Grue'
+          boatCrane: 'Grue',
+          mapArchives: 'Archives<br/>des cartes'
         },
         club: {
           spawnMainEntrance: 'Porte principale',
@@ -498,10 +503,9 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: 'Terrain d\'entraînement',
-          spawnBarrak: 'Parking',
+          spawnParking: 'Parking',
           spawnShootingRange: 'Stand de tir',
           armory: 'Armuererie',
-          alleyStairs: 'Allée avec<br/>escalier latéral',
           lockers: 'Vestiaires',
           corridor: 'Couloir',
           mainStairs: 'Escalier<br/>principal',
@@ -540,7 +544,8 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: 'Allée avec<br/>escalier latéral',
           sideStairs: 'Escalier<br/>latéral',
           garageTop: 'Toit du garage',
-          rooftop: 'Toit'
+          rooftop: 'Toit',
+          parkingEntrance: 'Entrée du parking'
         },
         house: {
           spawnConstructionSite: 'Chantier',
@@ -618,6 +623,7 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: 'Entrée<br/>du bar à<br/>cocktails',
           westMainStreet: 'Rue principale - Ouest',
           mainStreet: 'Rue principale',
+          eastMainStreet: 'Rue principale - Est',
           bakeryParking: 'Parking de la<br/>boulangerie',
           bakeryRoof: 'Toit de la<br/>boulangerie',
           cafeRoofTop: 'Toit du café',
@@ -679,7 +685,8 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: 'Entrée de la<br/>salle de réunion',
           garageRoof: 'Toit du garage',
           dormsRoof: 'Toit du<br/>dortoir',
-          meetingHallRoof: 'Toit de<br/>la salle<br/>de réunnion'
+          meetingHallRoof: 'Toit de<br/>la salle<br/>de réunnion',
+          supplyCloset: 'Placard'
         },
         plane: {
           spawnOfficialEntrance: 'Entrée principale',
@@ -720,7 +727,8 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           caterer: 'Cafétéria',
           serverRoomA: 'Salle des serveurs A',
           serverRoomB: 'Salle des serveurs B',
-          technicalSeating: 'Centre technique'
+          technicalSeating: 'Centre technique',
+          ladderRoom: 'Salle avec<br/>une échelle'
         },
         skyscraper: {
           helipad: 'Héliport',
@@ -819,7 +827,11 @@ var R6MapsLangTermsFrench = (function(R6MapsLangTerms, undefined) {
           eastGlacier: 'Glacier est',
           frozenRiver: 'Rivière gelée',
           zodiac: 'Bateau pneumatique',
-          westHullBreach: 'Brèche de la coque ouest'
+          westHullBreach: 'Brèche de la coque ouest',
+          kingOfTheWorld: 'Roi du<br/>monde',
+          roof: 'Toit',
+          anchorName: 'Ancre',
+          aklarkSubEntrance: 'Entrée de la<br/>salle de<br/>l\'Aklark'
         }
       }
     };

--- a/dev/js/langs/r6-maps.lang-terms.ja.js
+++ b/dev/js/langs/r6-maps.lang-terms.ja.js
@@ -166,6 +166,7 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           courtyard: '中庭',
           centralHallway: '中央廊下',
           diningRoom: 'ダイニングルーム',
+          eastBalcony: '',
           eastCorridor: '東通路',
           eastStairs: '東階段',
           festival: 'フェスティバル会場',
@@ -191,6 +192,7 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           trophyRoom: '記念品室',
           upperLibrary: '図書室2階',
           vistaHallway: '吹き抜け<br/>の廊下',
+          westBalcony: '',
           westCorridor: '西通路'
         },
         border: {
@@ -470,6 +472,8 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           schoolAlley: '学校通り',
           footballPitch: 'フットボール場',
           market: '市場',
+          marketAlley: '',
+          schoolRooftops: '',
           street: '通り',
           rooftops: '屋上',
           courtyard: '中庭',
@@ -479,10 +483,9 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: '訓練場',
-          spawnBarrak: '兵舎',
+          spawnParking: '兵舎',
           spawnShootingRange: '射撃練習場',
           armory: '武器庫',
-          alleyStairs: '',
           lockers: 'ロッカー',
           corridor: '通路',
           mainStairs: 'メイン階段',
@@ -521,7 +524,8 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: '側面階段<br/>路地',
           sideStairs: '側面階段',
           garageTop: 'ガレージ屋根',
-          rooftop: '屋上'
+          rooftop: '屋上',
+          parkingEntrance: ''
         },
         house: {
           spawnConstructionSite: '資材置き場',
@@ -620,7 +624,8 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: '管制センター<br/>屋上',
           dockStairs: 'ドック階段',
           parking: '駐車場',
-          boatCrane: 'ボートクレーン'
+          boatCrane: 'ボートクレーン',
+          mapArchives: ''
         },
         kafe: {
           spawnRiverDocks: '桟橋',
@@ -658,6 +663,7 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: 'カクテル<br/>ラウンジ<br/>入口',
           westMainStreet: 'メインストリート西',
           mainStreet: 'メインストリート',
+          eastMainStreet: '',
           bakeryParking: 'ベーカリー<br/>駐車場',
           bakeryRoof: 'ベーカリー屋上',
           cafeRoofTop: 'カフェ屋上',
@@ -719,7 +725,8 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: '会議室入口',
           garageRoof: 'ガレージ屋上',
           dormsRoof: '共同寝室<br/>屋根',
-          meetingHallRoof: '会議ホール<br/>屋根'
+          meetingHallRoof: '会議ホール<br/>屋根',
+          supplyCloset: ''
         },
         plane: {
           spawnOfficialEntrance: '前方搭乗口',
@@ -760,7 +767,8 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           caterer: 'サービスドア',
           serverRoomA: 'サーバールームA',
           serverRoomB: 'サーバールームB',
-          technicalSeating: 'テックシート'
+          technicalSeating: 'テックシート',
+          ladderRoom: ''
         },
         skyscraper: {
           helipad: 'ヘリポート',
@@ -860,7 +868,11 @@ var R6MapsLangTermsJapanese = (function(R6MapsLangTerms, undefined) {
           eastGlacier: '東側グレーシャー',
           frozenRiver: '冷たい川',
           zodiac: 'ゾディアック',
-          westHullBreach: '船体西側ブリーチ'
+          westHullBreach: '船体西側ブリーチ',
+          kingOfTheWorld: '',
+          roof: '',
+          anchorName: '',
+          aklarkSubEntrance: ''
         }
       }
     };

--- a/dev/js/langs/r6-maps.lang-terms.js
+++ b/dev/js/langs/r6-maps.lang-terms.js
@@ -190,6 +190,7 @@ var R6MapsLangTerms = (function(undefined) {
           courtyard: 'Courtyard',
           centralHallway: 'Central<br/>Hallway',
           diningRoom: 'Dining Room',
+          eastBalcony: 'East Balcony<br/>(not shown)',
           eastCorridor: 'East<br/>Corridor',
           eastStairs: 'East<br/>Stairs',
           festival: 'Festival',
@@ -215,6 +216,7 @@ var R6MapsLangTerms = (function(undefined) {
           trophyRoom: 'Trophy<br/>Room',
           upperLibrary: 'Upper<br/>Library',
           vistaHallway: 'Vista<br/>Hallway',
+          westBalcony: 'West Balcony<br/>(not shown)',
           westCorridor: 'West<br/>Corridor'
         },
         border: {
@@ -494,6 +496,8 @@ var R6MapsLangTerms = (function(undefined) {
           schoolAlley: 'School Alley',
           footballPitch: 'Football Pitch',
           market: 'Market',
+          marketAlley: 'Market<br/>Alley',
+          schoolRooftops: 'School<br/>Rooftops',
           street: 'Street',
           rooftops: 'Rooftops',
           courtyard: 'Courtyard',
@@ -503,10 +507,9 @@ var R6MapsLangTerms = (function(undefined) {
         },
         hereford: {
           spawnTrainingCourse: 'Training Course',
-          spawnBarrak: 'Barrak',
+          spawnParking: 'Parking',
           spawnShootingRange: 'Shooting Range',
           armory: 'Armory',
-          alleyStairs: 'Alley<br/>Stairs',
           lockers: 'Lockers',
           corridor: 'Corridor',
           mainStairs: 'Main<br/>Stairs',
@@ -545,7 +548,8 @@ var R6MapsLangTerms = (function(undefined) {
           sideStairsAlley: 'Side Stairs<br/>Alley',
           sideStairs: 'Side<br/>Stairs',
           garageTop: 'Garage Top',
-          rooftop: 'Rooftop'
+          rooftop: 'Rooftop',
+          parkingEntrance: 'Parking Entrance'
         },
         house: {
           spawnConstructionSite: 'Construction Site',
@@ -644,7 +648,8 @@ var R6MapsLangTerms = (function(undefined) {
           controlCenterRoof: 'Control<br/>Center<br/>Roof',
           dockStairs: 'Dock Stairs',
           parking: 'Parking',
-          boatCrane: 'Boat Crane'
+          boatCrane: 'Boat Crane',
+          mapArchives: 'Map<br/>Archives'
         },
         kafe: {
           spawnRiverDocks: 'River Docks',
@@ -682,6 +687,7 @@ var R6MapsLangTerms = (function(undefined) {
           cocktailLoungeEntrance: 'Cocktail<br/>Lounge<br/>Entrance',
           westMainStreet: 'West Main Street',
           mainStreet: 'Main Street',
+          eastMainStreet: 'East Main Street',
           bakeryParking: 'Bakery<br/>Parking',
           bakeryRoof: 'Bakery Roof',
           cafeRoofTop: 'Cafe Roof Top',
@@ -743,7 +749,8 @@ var R6MapsLangTerms = (function(undefined) {
           meetingHallEntrance: 'Meeting Hall<br/>Entrance',
           garageRoof: 'Garage Roof',
           dormsRoof: 'Dorms<br/>Roof',
-          meetingHallRoof: 'Meeting<br/>Hall<br/>Roof'
+          meetingHallRoof: 'Meeting<br/>Hall<br/>Roof',
+          supplyCloset: 'Supply<br/>Closet'
         },
         plane: {
           spawnOfficialEntrance: 'Official Entrance',
@@ -784,7 +791,8 @@ var R6MapsLangTerms = (function(undefined) {
           caterer: 'Caterer',
           serverRoomA: 'Server Room A',
           serverRoomB: 'Server Room B',
-          technicalSeating: 'Technical Seating'
+          technicalSeating: 'Technical Seating',
+          ladderRoom: 'Ladder<br/>Room'
         },
         skyscraper: {
           helipad: 'Helipad',
@@ -884,7 +892,11 @@ var R6MapsLangTerms = (function(undefined) {
           eastGlacier: 'East Glacier',
           frozenRiver: 'Frozen River',
           zodiac: 'Zodiac',
-          westHullBreach: 'West Hull Breach'
+          westHullBreach: 'West Hull Breach',
+          kingOfTheWorld: 'King of<br/>the World',
+          roof: 'Roof',
+          anchorName: 'Anchor',
+          aklarkSubEntrance: 'Aklark Sub<br/>Entrance'
         }
       }
     };

--- a/dev/js/langs/r6-maps.lang-terms.kr.js
+++ b/dev/js/langs/r6-maps.lang-terms.kr.js
@@ -156,6 +156,7 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           courtyard: '정원',
           centralHallway: '중앙<br/>복도',
           diningRoom: '식당',
+          eastBalcony: '',
           eastCorridor: '동쪽<br/>통로',
           eastStairs: '동쪽<br/>계단',
           festival: '캠퍼스 공터',
@@ -181,6 +182,7 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           trophyRoom: '트로피<br/>전시실',
           upperLibrary: '도서관<br/>상부',
           vistaHallway: '조망<br/>복도',
+          westBalcony: '',
           westCorridor: '서쪽<br/>통로'
         },
         border: {
@@ -421,6 +423,8 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           schoolAlley: '학교 골목',
           footballPitch: '축구 경기장',
           market: '시장',
+          marketAlley: '',
+          schoolRooftops: '',
           street: '도로',
           rooftops: '옥상',
           courtyard: '정원',
@@ -430,10 +434,9 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: '훈련 코스',
-          spawnBarrak: '주차장',
+          spawnParking: '주차장',
           spawnShootingRange: '사격장',
           armory: '무기고',
-          alleyStairs: '골목<br/>계단',
           lockers: '탈의실',
           corridor: '통로',
           mainStairs: '중앙<br/>계단',
@@ -472,7 +475,8 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: '측면 계단<br/>골목',
           sideStairs: '측면<br/>계단',
           garageTop: '차고 지붕',
-          rooftop: '옥상'
+          rooftop: '옥상',
+          parkingEntrance: ''
         },
         house: {
           spawnConstructionSite: '건설 현장',
@@ -571,7 +575,8 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: '통제소<br/>지붕',
           dockStairs: '선착장 계단',
           parking: '주차장',
-          boatCrane: '보트 기중기'
+          boatCrane: '보트 기중기',
+          mapArchives: ''
         },
         kafe: {
           spawnRiverDocks: '강 선착장',
@@ -609,6 +614,7 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: '칵테일<br/>라운지<br/>입구',
           westMainStreet: '서쪽 대로',
           mainStreet: '대로',
+          eastMainStreet: '',
           bakeryParking: '제과점<br/>주차장',
           bakeryRoof: '제과점 지붕',
           cafeRoofTop: '카페 옥상',
@@ -670,7 +676,8 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: '회관<br/>입구',
           garageRoof: '차고 지붕',
           dormsRoof: '기숙사<br/>지붕',
-          meetingHallRoof: '회관 지붕'
+          meetingHallRoof: '회관 지붕',
+          supplyCloset: ''
         },
         plane: {
           spawnOfficialEntrance: '주 출입구',
@@ -711,7 +718,8 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           caterer: '기내식<br/>공급 지점',
           serverRoomA: '서버실 A',
           serverRoomB: '서버실 B',
-          technicalSeating: '정비공 좌석'
+          technicalSeating: '정비공 좌석',
+          ladderRoom: ''
         },
         skyscraper: {
           helipad: '외부 헬기장',
@@ -811,7 +819,11 @@ var R6MapsLangTermsKorean = (function(R6MapsLangTerms, undefined) {
           eastGlacier: '동쪽 빙하',
           frozenRiver: '얼어붙은 강',
           zodiac: '구명정',
-          westHullBreach: '서쪽 선체 균열'
+          westHullBreach: '서쪽 선체 균열',
+          kingOfTheWorld: '',
+          roof: '',
+          anchorName: '',
+          aklarkSubEntrance: ''
         }
       }
     };

--- a/dev/js/langs/r6-maps.lang-terms.pt.js
+++ b/dev/js/langs/r6-maps.lang-terms.pt.js
@@ -165,6 +165,7 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           courtyard: 'Pátio',
           centralHallway: 'Corredor<br/>Central',
           diningRoom: 'Sala de<br/>Jantar',
+          eastBalcony: '',
           eastCorridor: 'Corredor<br/>Leste',
           eastStairs: 'Escadaria<br/>Leste',
           festival: 'Festival',
@@ -190,6 +191,7 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           trophyRoom: 'Sala de<br/>Troféus',
           upperLibrary: 'Biblioteca<br/>Superior',
           vistaHallway: 'Corredor<br/>Vista',
+          westBalcony: '',
           westCorridor: 'Corredor<br/>Oeste'
         },
         border: {
@@ -430,6 +432,8 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           schoolAlley: 'Beco da<br/>Escola',
           footballPitch: 'Campo da<br/>Pelada',
           market: 'Mercado',
+          marketAlley: '',
+          schoolRooftops: '',
           street: 'Rua',
           rooftops: 'Telhados',
           courtyard: 'Pátio',
@@ -439,10 +443,9 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: 'Pista de<br/>Treinamento',
-          spawnBarrak: 'Alojamento',
+          spawnParking: 'Alojamento',
           spawnShootingRange: 'Estand de<br/>Tiro',
           armory: 'Armaria',
-          alleyStairs: 'Escadaria do<br/>Beco',
           lockers: 'Vestiário',
           corridor: 'Corredor',
           mainStairs: 'Escadaria<br/>Principal',
@@ -481,7 +484,8 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: 'Beco da<br/>Escadaria<br/>Lateral',
           sideStairs: 'Escadaria<br/>Lateral',
           garageTop: 'Telhado da<br/>Garagem',
-          rooftop: 'Telhado'
+          rooftop: 'Telhado',
+          parkingEntrance: ''
         },
         house: {
           spawnConstructionSite: 'Canteiro de<br/>Obras',
@@ -580,7 +584,8 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: 'Telhado do<br/>Controle',
           dockStairs: 'Escadaria das<br/>Docas',
           parking: 'Estacionamento',
-          boatCrane: 'Grua dos<br/>Botes'
+          boatCrane: 'Grua dos<br/>Botes',
+          mapArchives: ''
         },
         kafe: {
           spawnRiverDocks: 'Docas',
@@ -618,6 +623,7 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: 'Entrada do<br/>Cocktail',
           westMainStreet: 'Rua<br/>Principal<br/>Oeste',
           mainStreet: 'Rua<br/>Principal',
+          eastMainStreet: '',
           bakeryParking: 'Estacionamento da<br/>Padaria',
           bakeryRoof: 'Telhado da<br/>Padaria',
           cafeRoofTop: 'Telhado do<br/>Cafe',
@@ -679,7 +685,8 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: 'Entrada da<br/>Sala de<br/>Reuniões',
           garageRoof: 'Telhado da<br/>Garagem',
           dormsRoof: 'Telhado do<br/>Dormitório',
-          meetingHallRoof: 'Telhado da<br/>Sala de<br/>Reuniões'
+          meetingHallRoof: 'Telhado da<br/>Sala de<br/>Reuniões',
+          supplyCloset: ''
         },
         plane: {
           spawnOfficialEntrance: 'Entrada<br/>Oficial',
@@ -720,7 +727,8 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           caterer: 'Serviço<br/>Caterer',
           serverRoomA: 'Sala do<br/>Servidor A',
           serverRoomB: 'Sala do<br/>Servidor B',
-          technicalSeating: 'Área<br/>Técnica'
+          technicalSeating: 'Área<br/>Técnica',
+          ladderRoom: ''
         },
         skyscraper: {
           helipad: 'Heliponto',
@@ -820,7 +828,11 @@ var R6MapsLangTermsPortBrazil = (function(R6MapsLangTerms, undefined) {
           eastGlacier: 'Geleria<br/>Leste',
           frozenRiver: 'Rio<br/>Congelado',
           zodiac: 'Bote',
-          westHullBreach: 'Buraco no Casco<br/>Oeste'
+          westHullBreach: 'Buraco no Casco<br/>Oeste',
+          kingOfTheWorld: '',
+          roof: '',
+          anchorName: '',
+          aklarkSubEntrance: ''
         }
       }
     };

--- a/dev/js/langs/r6-maps.lang-terms.ru.js
+++ b/dev/js/langs/r6-maps.lang-terms.ru.js
@@ -171,6 +171,7 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           courtyard: 'Внутренний двор',
           centralHallway: 'Главный<br/>вестибюль',
           diningRoom: 'Столовая',
+          eastBalcony: '',
           eastCorridor: 'Восточный<br/>коридор',
           eastStairs: 'Восточная<br/>лестница',
           festival: 'Ярмарка',
@@ -196,6 +197,7 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           trophyRoom: 'Комната<br/>трофеев',
           upperLibrary: 'Верхняя<br/>библиотека',
           vistaHallway: 'Открытый<br/>коридор',
+          westBalcony: '',
           westCorridor: 'Западный<br/>коридор'
         },
         border: {
@@ -436,6 +438,8 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           schoolAlley: 'Школа – Переулок',
           footballPitch: 'Площадка (футбол)',
           market: 'Рынок',
+          marketAlley: '',
+          schoolRooftops: '',
           street: 'Улица',
           rooftops: 'Крыша',
           courtyard: 'Двор',
@@ -445,10 +449,9 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: 'Полоса препятствий',
-          spawnBarrak: 'Парковка',
+          spawnParking: 'Парковка',
           spawnShootingRange: 'Стрельбище',
           armory: 'Оружейная',
-          alleyStairs: 'Бок. лестница<br/>Проход',
           lockers: 'Раздевалка',
           corridor: 'Коридор',
           mainStairs: 'Главная<br/>лестница',
@@ -487,7 +490,8 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: 'Бок. лестница<br/>Проход',
           sideStairs: 'Боковая<br/>лестница',
           garageTop: 'Крыша гаража',
-          rooftop: 'Крыша'
+          rooftop: 'Крыша',
+          parkingEntrance: ''
         },
         house: {
           spawnConstructionSite: 'Стройплощадка',
@@ -586,7 +590,8 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: 'Диспетческая<br/>Крыша',
           dockStairs: 'Док – Лестница',
           parking: 'Парковка',
-          boatCrane: 'Кран'
+          boatCrane: 'Кран',
+          mapArchives: ''
         },
         kafe: {
           spawnRiverDocks: 'Причал',
@@ -624,6 +629,7 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: 'Кокт. зал<br/>Вход',
           westMainStreet: 'Центральная улица, запад',
           mainStreet: 'Центральная улица',
+          eastMainStreet: '',
           bakeryParking: 'Парковка у<br/>пекарни',
           bakeryRoof: 'Крыша пекарни',
           cafeRoofTop: 'Крыша кафе',
@@ -685,7 +691,8 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: 'Конференц-зал<br/>Вход',
           garageRoof: 'Крыша гаража',
           dormsRoof: 'Крыша спальн. комнаты',
-          meetingHallRoof: 'Крыша<br/>конференц-зала'
+          meetingHallRoof: 'Крыша<br/>конференц-зала',
+          supplyCloset: ''
         },
         plane: {
           spawnOfficialEntrance: 'Главный вход',
@@ -726,7 +733,8 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           caterer: 'Поставки провизии',
           serverRoomA: 'Серверная A',
           serverRoomB: 'Серверная B',
-          technicalSeating: 'Место техника'
+          technicalSeating: 'Место техника',
+          ladderRoom: ''
         },
         skyscraper: {
           helipad: 'Верт. площадка',
@@ -826,7 +834,11 @@ var R6MapsLangTermsRussian = (function(R6MapsLangTerms, undefined) {
           eastGlacier: 'Восток<br/>Ледник',
           frozenRiver: 'Замёрзшая река',
           zodiac: 'Шлюпка',
-          westHullBreach: 'Западная часть<br/>Брешь'
+          westHullBreach: 'Западная часть<br/>Брешь',
+          kingOfTheWorld: '',
+          roof: '',
+          anchorName: '',
+          aklarkSubEntrance: ''
         }
       }
     };

--- a/dev/js/langs/r6-maps.lang-terms.zh_cn.js
+++ b/dev/js/langs/r6-maps.lang-terms.zh_cn.js
@@ -167,6 +167,7 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           courtyard: '庭院',
           centralHallway: '中央过道',
           diningRoom: '饭厅',
+          eastBalcony: '',
           eastCorridor: '东侧廊道',
           eastStairs: '东侧<br/>楼梯',
           festival: '展览场',
@@ -192,6 +193,7 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           trophyRoom: '奖杯陈列室',
           upperLibrary: '上层图书馆',
           vistaHallway: '景观厅<br/>过道',
+          westBalcony: '',
           westCorridor: '西侧廊道'
         },
         border: {
@@ -471,6 +473,8 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           schoolAlley: '学校走道',
           footballPitch: '美式足球场',
           market: '市场',
+          marketAlley: '',
+          schoolRooftops: '',
           street: '街道',
           rooftops: '屋上',
           courtyard: '中庭',
@@ -480,10 +484,9 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
         },
         hereford: {
           spawnTrainingCourse: '训练场',
-          spawnBarrak: '停车场',
+          spawnParking: '停车场',
           spawnShootingRange: '靶场',
           armory: '军械室',
-          alleyStairs: '侧边楼梯<br/>小径',
           lockers: '寄物柜区',
           corridor: '廊道',
           mainStairs: '主楼梯',
@@ -522,7 +525,8 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           sideStairsAlley: '侧边楼梯<br/>小径',
           sideStairs: '侧边楼梯',
           garageTop: '车库顶部',
-          rooftop: '屋顶'
+          rooftop: '屋顶',
+          parkingEntrance: ''
         },
         house: {
           spawnConstructionSite: '建筑工地<br/>（施工场）',
@@ -621,7 +625,8 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           controlCenterRoof: '控制中心屋顶',
           dockStairs: '码头楼梯',
           parking: '停车场',
-          boatCrane: '船只起重机'
+          boatCrane: '船只起重机',
+          mapArchives: ''
         },
         kafe: {
           spawnRiverDocks: '河岸码头',
@@ -659,6 +664,7 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           cocktailLoungeEntrance: '酒吧间<br/>入口',
           westMainStreet: '西侧主街',
           mainStreet: '主街',
+          eastMainStreet: '',
           bakeryParking: '烘焙坊<br/>停车场',
           bakeryRoof: '烘焙坊屋顶',
           cafeRoofTop: '咖啡馆屋顶',
@@ -720,7 +726,8 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           meetingHallEntrance: '会议厅入口',
           garageRoof: '车库屋顶',
           dormsRoof: '宿舍屋顶',
-          meetingHallRoof: '会议厅<br/>屋顶'
+          meetingHallRoof: '会议厅<br/>屋顶',
+          supplyCloset: ''
         },
         plane: {
           spawnOfficialEntrance: '主要入口',
@@ -761,7 +768,8 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           caterer: '供餐口',
           serverRoomA: '机房 A',
           serverRoomB: '机房 B',
-          technicalSeating: '技术人员座位'
+          technicalSeating: '技术人员座位',
+          ladderRoom: ''
         },
         skyscraper: {
           helipad: '停机坪',
@@ -861,7 +869,11 @@ var R6MapsLangTermsSimplifiedChinese = (function(R6MapsLangTerms, undefined) {
           eastGlacier: '东侧冰川',
           frozenRiver: '冰河',
           zodiac: '黄道带',
-          westHullBreach: '西船身突破口'
+          westHullBreach: '西船身突破口',
+          kingOfTheWorld: '',
+          roof: '',
+          anchorName: '',
+          aklarkSubEntrance: ''
         }
       }
     };

--- a/dev/js/r6-maps.map-data.js
+++ b/dev/js/r6-maps.map-data.js
@@ -362,7 +362,9 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 2, top: -204, left: 764, description: bartlettTerms.gardenPass },
           { floor: 2, top: 73, left: 764, description: bartlettTerms.gardenPass },
           { outdoor: true, top: 298, left: 655, description: bartlettTerms.mainGate, hardToRead: true },
-          { outdoor: true, top: 615, left: 655, description: bartlettTerms.mainGate, hardToRead: true }
+          { outdoor: true, top: 615, left: 655, description: bartlettTerms.mainGate, hardToRead: true },
+          { outdoor: true, top: 704, left: 573, description: bartlettTerms.eastBalcony, hardToRead: true },
+          { outdoor: true, top: 704, left: -349, description: bartlettTerms.westBalcony, hardToRead: true }
         ]
       },
       border: {
@@ -1311,6 +1313,9 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 1, top: -143, left: 213, description: favelaTerms.courtyard },
           { floor: 2, top: -143, left: 213, description: favelaTerms.courtyard },
           { outdoor: true, top: -330, left: -34, description: favelaTerms.accessAlley },
+          { outdoor: true, top: 242, left: -294, description: favelaTerms.marketAlley, smaller: true },
+          { outdoor: true, top: -552, left: -227, description: favelaTerms.schoolRooftops },
+          { outdoor: true, top: -403, left: 95, description: favelaTerms.schoolRooftops, smaller: true },
           { floor: 1, top: 344, left: -90, description: favelaTerms.shop },
           { floor: 3, top: 237, left: -412, description: favelaTerms.marketRooftops, hardToRead: true },
           { floor: 3, top: 420, left: -412, description: favelaTerms.marketRooftops, hardToRead: true }
@@ -1415,13 +1420,11 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
         ],
         spawnPoints: [
           { letter: spawnTerms.a, top: 322, left: -789, description: herefordTerms.spawnTrainingCourse },
-          { letter: spawnTerms.b, top: 236, left: 703, description: herefordTerms.spawnBarrak },
+          { letter: spawnTerms.b, top: 236, left: 703, description: herefordTerms.spawnParking },
           { letter: spawnTerms.c, top: -630, left: 27, description: herefordTerms.spawnShootingRange }
         ],
         roomLabels: [
           { floor: 0, top: 263, left: -86, description: herefordTerms.armory },
-          { floor: 0, top: 50, left: 200, description: herefordTerms.alleyStairs },
-          { floor: 1, top: 50, left: 200, description: herefordTerms.alleyStairs },
           { floor: 0, top: 191, left: 94, description: herefordTerms.lockers },
           { floor: 0, top: 272, left: 2, description: herefordTerms.corridor },
           { floor: 0, top: 407, left: 1, description: herefordTerms.mainStairs },
@@ -1465,7 +1468,8 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { outdoor: true, top: 29, left: -317, description: herefordTerms.chapelGate },
           { outdoor: true, top: 286, left: -336, description: herefordTerms.forkliftArea },
           { outdoor: true, top: 187, left: 266, description: herefordTerms.sideStairsAlley },
-          { outdoor: true, top: 50, left: 117, description: herefordTerms.basementEntrance },
+          { outdoor: true, top: 50, left: 132, description: herefordTerms.basementEntrance },
+          { outdoor: true, top: 583, left: 646, description: herefordTerms.parkingEntrance },
           { floor: 1, top: 116, left: 190, description: herefordTerms.sideStairs },
           { floor: 2, top: 116, left: 190, description: herefordTerms.sideStairs },
           { floor: 3, top: 116, left: 190, description: herefordTerms.sideStairs },
@@ -1768,6 +1772,7 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 3, top: 129, left: 353, smaller: true, description: kafeTerms.cocktailLoungeEntrance },
           { outdoor: true, top: -379, left: -588, description: kafeTerms.westMainStreet },
           { outdoor: true,  top: -379, left: 132, description: kafeTerms.mainStreet },
+          { outdoor: true,  top: -379, left: 851, description: kafeTerms.eastMainStreet },
           { outdoor: true,  top: 71, left: -337, description: kafeTerms.bakeryParking },
           { floor: 2,  top: 174, left: -162, description: kafeTerms.bakeryRoof },
           { floor: 3,  top: 174, left: -162, description: kafeTerms.bakeryRoof },
@@ -1939,6 +1944,7 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { outdoor: true, top: -171, left: -568, description: kanalTerms.forkliftAlley },
           { outdoor: true, top: 122, left: -568, description: kanalTerms.forkliftAlley },
           { outdoor: true, top: 390, left: -331, description: kanalTerms.frontLawn },
+          { floor: 2, top: -36, left: 342, description: kanalTerms.mapArchives, hardToRead: true },
           { floor: 1, top: 302, left: -413, description: kanalTerms.basementStairs },
           { floor: 4, top: 107, left: -356, description: kanalTerms.coastGuardRoof },
           { floor: 3, top: 107, left: -356, description: kanalTerms.coastGuardRoof },
@@ -2062,6 +2068,7 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
         ],
         roomLabels: [
           { floor: 0, top: -321, left: 142, description: oregonTerms.towerStairs },
+          { floor: 0, top: 29, left: 150, description: oregonTerms.supplyCloset, hardToRead: true },
           { floor: 0, top: -198, left: 197, description: oregonTerms.boilerRoom },
           { floor: 0, top: -146, left: 219, description: oregonTerms.electricRoom },
           { floor: 0, top: -173, left: 299, description: oregonTerms.bunkerEntrance },
@@ -2285,7 +2292,8 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 3, top: 3, left: -221, hardToRead: true, description: planeTerms.serverRoomB },
           { floor: 3, top: 0, left: -428, hardToRead: true, description: planeTerms.serverRoomB },
           { floor: 1, top: -30, left: 222, smaller: true, description: planeTerms.technicalSeating },
-          { floor: 2, top: 112, left: -453, hardToRead: true, description: planeTerms.caterer }
+          { floor: 2, top: 112, left: -453, hardToRead: true, description: planeTerms.caterer },
+          { floor: 2, top: -54, left: -177, hardToRead: true, description: planeTerms.ladderRoom, smaller: true }
         ]
       },
       skyscraper: {
@@ -2515,7 +2523,9 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 3, top: 116, left: 331, otherFloor: 'up' },
           { floor: 4, top: 116, left: 331, otherFloor: 'down' },
           { floor: 3, top: -93, left: 331, otherFloor: 'up' },
-          { floor: 4, top: -93, left: 331, otherFloor: 'down' }
+          { floor: 4, top: -93, left: 331, otherFloor: 'down' },
+          { floor: 2, top: -39, left: 610, otherFloor: 'up' },
+          { floor: 3, top: -39, left: 610, otherFloor: 'down' }
         ],
         cameras: [
           {
@@ -2627,6 +2637,8 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 3, top: -89, left: 226, description: yachtTerms.westDeck },
           { floor: 3, top: 17, left: 390, description: yachtTerms.frontDeck },
           { floor: 3, top: 17, left: 723, description: yachtTerms.frontDeck },
+          { floor: 3, top: 17, left: 801, description: yachtTerms.kingOfTheWorld, hardToRead: true },
+          { floor: 5, top: 17, left: 108, description: yachtTerms.roof },
           { floor: 3, top: 17, left: 325, description: yachtTerms.masterBedroom },
           { floor: 3, top: 4, left: 77, description: yachtTerms.casino },
           { floor: 3, top: -9, left: 170, description: yachtTerms.pokerRoom },
@@ -2664,11 +2676,13 @@ var R6MapsData = (function(R6MapsLangTerms, undefined){
           { floor: 3, top: -57, left: 252, description: yachtTerms.frontStairs },
           { outdoor: true, hardToRead: true, top: -262, left: -43, description: yachtTerms.submarine },
           { outdoor: true, hardToRead: true, top: -206, left: -306, description: yachtTerms.westGlacier },
-          { outdoor: true, hardToRead: true, top: 259, left: 304, description: yachtTerms.eastHullBreach },
+          { outdoor: true, hardToRead: true, top: 232, left: 617, description: yachtTerms.eastHullBreach },
           { outdoor: true, hardToRead: true, top: 388, left: 100, description: yachtTerms.eastGlacier },
           { outdoor: true, hardToRead: true, top: 388, left: -304, description: yachtTerms.frozenRiver },
           { outdoor: true, top: 245, left: -569, hardToRead: true, description: yachtTerms.zodiac },
-          { outdoor: true, hardToRead: true, top: -145, left: 261, description: yachtTerms.westHullBreach }
+          { outdoor: true, hardToRead: true, top: -145, left: 261, description: yachtTerms.westHullBreach },
+          { floor: 2, top: -15, left: 553, description: yachtTerms.anchorName },
+          { floor: 2, top: 85, left: 454, description: yachtTerms.aklarkSubEntrance, smaller: true, hardToRead: true }
         ]
       }
       /*emptytemplate: {


### PR DESCRIPTION
@appleparan @MasterGroosha @warcy 

This PR covers some missing room names across various maps.  I was wondering if you would consider providing the translations for them?

For most languages I simply put a blank placeholder for now, as the names are not critical.  You can checkout this PR for which labels are needed.  Thanks!

_The following is a reference list of room names added, in case it helps find them on the map:_

**Bartlett University**
East Balcony - ADDED - Eastern Balcony next to Main Gate spawn
West Balcony - ADDED - Western Balcony next to Festival spawn 

**Favela**
Market Alley - ADDED - Small street between Market and Shop, leads to Biker’s Bedroom window. (Also displays outside Football Office’s side door.)
School Rooftops - ADDED - Rooftop on building between School Alley and Access Alley.

**Hereford Base**
Parking lot entrance - ADDED - To the East of Parking Lot and Northeast of Baracks (Next to large gate)
Barrak Spawn - ENGLISH CORRECTED/RENAMED TO ‘PARKING’ - probably no effect on translations
Alley Stairs - REMOVED (nothing required)

**Kanal**
Map archives - ADDED - Small Room in the Southeast corner of the Maps office.

**Kafe**
East Main Street - ADDED - East of the Main Street

**Oregon**
Supply Closet - ADDED - Small room in Supply Room, next to hostage spawn.

**Plane**
Ladder Room - ADDED - next to Press Section A and Security Room. 

**Yacht** 
King of the World - ADDED - Possible Easter egg? Located at the very top of the ship on the tip of the front deck.
Anchor- ADDED - Section between East Hull Breach and Boreal Sub Room, front of boat
Aklark Sub Entrance - ADDED - near anchor (southern door)
Roof- ADDED - Top of the boat